### PR TITLE
Allow capitals in the key

### DIFF
--- a/R/detect-citations.R
+++ b/R/detect-citations.R
@@ -33,7 +33,7 @@ bbt_detect_citations_chr <- function(content) {
   content <- paste0(content, collapse = "\n")
   refs <- stringr::str_match_all(
     content,
-    stringr::regex("[^a-zA-Z0-9\\\\]@([a-z0-9_.-]+)", multiline = TRUE, dotall = TRUE)
+    stringr::regex("[^a-zA-Z0-9\\\\]@([a-zA-Z0-9_.-]+)", multiline = TRUE, dotall = TRUE)
   )[[1]][, 2, drop =  TRUE]
 
   unique(refs)

--- a/tests/testthat/test-detect-citations.R
+++ b/tests/testthat/test-detect-citations.R
@@ -1,22 +1,22 @@
 
 test_that("regex for citations works", {
   expect_identical(
-    bbt_detect_citations_chr("\n@citation1 [@citation2] but not \\@citation3"),
-    c("citation1", "citation2")
+    bbt_detect_citations_chr("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] but not \\@citation3 and not not \\@citation2019NotValid"),
+    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author")
   )
 })
 
 test_that("detect_citations can operate on a character vector or file", {
   expect_identical(
-    bbt_detect_citations("\n@citation1 [@citation2] but not \\@citation3"),
-    c("citation1", "citation2")
+    bbt_detect_citations("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] but not \\@citation3 and not not \\@citation2019NotValid"),
+    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author")
   )
 
   file <- tempfile()
-  write("\n@citation1 [@citation2] but not \\@citation3", file)
+  write("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] but not \\@citation3 and not not \\@citation2019NotValid", file)
   expect_identical(
     bbt_detect_citations(file),
-    c("citation1", "citation2")
+    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author")
   )
   unlink(file)
 })


### PR DESCRIPTION
I am using BetterBibTex with `[auth:lower][year][shorttitle3_3]` key template. It creates capitalized keys and I thought some other people might use Zotero the same way, hence PR.