### PR TITLE
Citations must end with a letter or a number

### DIFF
--- a/R/detect-citations.R
+++ b/R/detect-citations.R
@@ -33,7 +33,7 @@ bbt_detect_citations_chr <- function(content) {
   content <- paste0(content, collapse = "\n")
   refs <- stringr::str_match_all(
     content,
-    stringr::regex("[^a-zA-Z0-9\\\\]@([a-zA-Z0-9_.-]+)", multiline = TRUE, dotall = TRUE)
+    stringr::regex("[^a-zA-Z0-9\\\\]@([a-zA-Z0-9_.-]+[a-zA-Z0-9])", multiline = TRUE, dotall = TRUE)
   )[[1]][, 2, drop =  TRUE]
 
   unique(refs)

--- a/tests/testthat/test-detect-citations.R
+++ b/tests/testthat/test-detect-citations.R
@@ -1,7 +1,7 @@
 
 test_that("regex for citations works", {
   expect_identical(
-    bbt_detect_citations_chr("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] but not \\@citation3 and not not \\@citation2019NotValid"),
+    bbt_detect_citations_chr("\n@citation1. \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author]. but not \\@citation3 and not not \\@citation2019NotValid"),
     c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author")
   )
 })


### PR DESCRIPTION
Thanks @paleolimbot for this excellent helper! I started converting some papers and came across this issue where citations at the end of a phrase would fail: i.e. `@author2020.` I'm not sure if this is the optimal solution, but my suggestion is that references should end with a letter or a number. 