### PR TITLE
Fix function name in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -55,7 +55,7 @@ bibliography: \"`r rbbt::bbt_write_bib('biblio.json', overwrite = TRUE)`\"
 ")
 ```
 
-This is still experimental, so file an issue if it fails! You can use `bbt_write_bib("biblio.json", bbt_detect_citation("file.Rmd"))` to do this manually.
+This is still experimental, so file an issue if it fails! You can use `bbt_write_bib("biblio.json", bbt_detect_citations("file.Rmd"))` to do this manually.
 
 ## Programmatically fetch bibliography info
 


### PR DESCRIPTION
```
> bbt_detect_citation
Error: object 'bbt_detect_citation' not found
> bbt_detect_citations
function (path = bbt_guess_citation_context(), locale = readr::default_locale()) 
{
    bbt_detect_citations_chr(readr::read_file(path, locale = locale))
}
<bytecode: 0x55bb717a2998>
<environment: namespace:rbbt>
```