### PR TITLE
Don't detect citations in code blocks

### DIFF
--- a/R/detect-citations.R
+++ b/R/detect-citations.R
@@ -12,7 +12,12 @@
 #' bbt_detect_citations("\n@citation1 and [@citation2] but not \\@citation3")
 #'
 bbt_detect_citations <- function(path = bbt_guess_citation_context(), locale = readr::default_locale()) {
-  bbt_detect_citations_chr(readr::read_file(path, locale = locale))
+  content <- stringr::str_replace_all(
+    readr::read_file(path, locale = locale),
+    stringr::regex('```([^`]*)```', multiline = TRUE, dotall = TRUE),
+    ''
+  )
+  bbt_detect_citations_chr(content)
 }
 
 #' @rdname bbt_detect_citations


### PR DESCRIPTION
I was having an issue where S4 slots in code blocks were being detected as citations.

Eg, `rbbt::bbt_write_bib` was resulting in error `Slot` not found with:

```
```{r eval=FALSE}

  MyObject[[1]]@Slot
  
``` # 

```

My fix was to drop all code blocks from the content object. It works for me, but not sure if it is robust for all situations.
