### PR TITLE
add compatibility with Quarto files 

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -17,8 +17,8 @@ bbt_bib_addin <- function() {
 
 bbt_update_bib_addin <- function() {
   context <- bbt_rstudio_editor_filepath()
-  if (!(tools::file_ext(context) %in% c("rmd", "Rmd"))) {
-    stop("Currently selected editor is not a .rmd or .Rmd file", call. = FALSE)
+  if (!(tools::file_ext(context) %in% c("qmd", "Qmd", "rmd", "Rmd"))) {
+    stop("Currently selected editor is not a .qmd, .rmd or .Rmd file", call. = FALSE)
   }
 
   message(sprintf('Running `bbt_update_bib("%s")`', context))


### PR DESCRIPTION
I wanted to use rbbt when working with Quarto files.

All I need to do was add .qmd files to the list of acceptable files in `bbt_update_bib_addin`. The addin then works with Quarto files in RStudio.