### PR TITLE
Detect citekeys that have colons in them

### DIFF
--- a/R/detect-citations.R
+++ b/R/detect-citations.R
@@ -51,7 +51,7 @@ bbt_detect_citations_chr <- function(text) {
 
   refs <- stringr::str_match_all(
     text,
-    stringr::regex("[^a-zA-Z0-9\\\\]@([a-zA-Z0-9_.-]+[a-zA-Z0-9])", multiline = TRUE, dotall = TRUE)
+    stringr::regex("[^a-zA-Z0-9\\\\]@([a-zA-Z0-9_\\.\\-:]+[a-zA-Z0-9])", multiline = TRUE, dotall = TRUE)
   )[[1]][, 2, drop = TRUE]
 
   unique(refs)

--- a/tests/testthat/test-detect-citations.R
+++ b/tests/testthat/test-detect-citations.R
@@ -1,22 +1,22 @@
 
 test_that("regex for citations works", {
   expect_identical(
-    bbt_detect_citations_chr("\n@citation1. \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author]. but not \\@citation3 and not not \\@citation2019NotValid"),
-    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author")
+    bbt_detect_citations_chr("\n@citation1. \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] [@author:2023]. but not \\@citation3 and not not \\@citation2019NotValid"),
+    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author", "author:2023")
   )
 })
 
 test_that("detect_citations can operate on a character vector or file", {
   expect_identical(
-    bbt_detect_citations("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] but not \\@citation3 and not not \\@citation2019NotValid"),
-    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author")
+    bbt_detect_citations("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] [@author:2023] but not \\@citation3 and not not \\@citation2019NotValid"),
+    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author", "author:2023")
   )
 
   file <- tempfile()
-  write("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] but not \\@citation3 and not not \\@citation2019NotValid", file)
+  write("\n@citation1 \n@citation1991AlphaBetaGamma [@citation2] [@citation2020author] [@author:2023] but not \\@citation3 and not not \\@citation2019NotValid", file)
   expect_identical(
     bbt_detect_citations(file),
-    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author")
+    c("citation1","citation1991AlphaBetaGamma", "citation2", "citation2020author", "author:2023")
   )
   unlink(file)
 })


### PR DESCRIPTION
Right now, rbbt fails to detect citekeys that have colons in them. For instance, in an .Rmd file that contains this:

```markdown
Lorem ipsum dolor sit amet, consectetur adipisicing elit [@Smith:2022]
```

…running `rbbt::bbt_update_bib("whatever.Rmd")` results in this error:

```
Error: not found: Smith
```

One of the default citekey patterns from BibDesk on macOS is `authorname:year`, and those carry over to Zotero when migrating from BibDesk to Zotero. Additionally, users can configure Better BibTeX to use colons in the citekey pattern.

This PR adds support for detecting citekeys with colons by expanding the detection regex.