### PR TITLE
add whitelists

### DIFF
--- a/R/detect-citations.R
+++ b/R/detect-citations.R
@@ -33,6 +33,17 @@ bbt_guess_citation_context <- function() {
   }
 }
 
+prepare_whitelists <- function(){
+  quarto_wl <- getOption("rbbt.whitelist.quarto")
+  user_wl <- getOption("rbbt.whitelist.user")
+  wl <- vector("character")
+  if(length(quarto_wl)>0)
+    wl <- c(wl, paste(paste0("(",quarto_wl, ")"), collapse="|"))
+  if(length(user_wl)>0)
+    wl <- c(wl, paste(paste0("(",user_wl, ")"), collapse="|"))
+  wl
+}
+
 bbt_detect_citations_chr <- function(text) {
   text <- paste0(text, collapse = "\n")
 
@@ -53,6 +64,8 @@ bbt_detect_citations_chr <- function(text) {
     text,
     stringr::regex("[^a-zA-Z0-9\\\\]@([a-zA-Z0-9_\\.\\-:]+[a-zA-Z0-9])", multiline = TRUE, dotall = TRUE)
   )[[1]][, 2, drop = TRUE]
+
+  refs <- stringr::str_subset(string = refs, pattern =prepare_whitelists(), negate = TRUE)
 
   unique(refs)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,20 @@
+#' .onLoad getOption package settings
+#'
+#' @param libname defunct
+#' @param pkgname defunct
+#'
+#' @return
+#'
+#' @examples
+#' getOption("rbbt.whitelist.quarto")
+.onLoad <- function(libname, pkgname) {
+  op <- options()
+  op_rbbt <- list(
+    rbbt.whitelist.quarto=c("^fig-", "^tbl-", "^eq-", "^sec-", "^lst-", "^thm-"),
+    rbbt.whitelist.user=c()
+    )
+  toset <- !(names(op_rbbt) %in% names(op))
+  if (any(toset)) options(op_rbbt[toset])
+
+  invisible()
+}


### PR DESCRIPTION
I implemented whitelists in options that are loaded onLoad. 
The whitelists are extensible via `options("rbbt.whitelist.user"=c())`. 

The vector whitelists are converted to regex in internal function and then excluded from the vector of keyes using the `str_subset` as you suggested.